### PR TITLE
Use typo3/cms-core instead of typo3/cms

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "license": ["GPL-2.0+"],
     "keywords": ["pdf", "TYPO3", "powermail"],
     "require": {
-        "typo3/cms": "^8.7|^9",
+        "typo3/cms-core": "^8.7|^9",
         "tmw/fpdm": "^2.9",
 		"in2code/powermail": "^5|^6"
     },


### PR DESCRIPTION
TYPO3 9.5 supports use of composer but required a package that makes it impossible to use `typo3/cms-core` like most people do. This is a fix for `powermailpdf` version `2.4.5` for those of us who for one reason or another cannot upgrade yet.