### PR TITLE
TYPO3 v11 ready

### DIFF
--- a/Classes/Pdf.php
+++ b/Classes/Pdf.php
@@ -23,6 +23,13 @@ use TYPO3\CMS\Fluid\View\StandaloneView;
  */
 class Pdf
 {
+    /** @var ResourceFactory */
+    protected $resourceFactory;
+
+    public function __construct(ResourceFactory $resourceFactory)
+    {
+        $this->resourceFactory = $resourceFactory;
+    }
 
     /**
      * @param Mail $mail
@@ -35,7 +42,7 @@ class Pdf
         $settings = $GLOBALS['TSFE']->tmpl->setup['plugin.']['tx_powermailpdf.']['settings.'];
 
         /** @var Folder $folder */
-        $folder = ResourceFactory::getInstance()->getFolderObjectFromCombinedIdentifier($settings['target.']['pdf']);
+        $folder = $this->resourceFactory->getFolderObjectFromCombinedIdentifier($settings['target.']['pdf']);
 
         // Include \FPDM library from phar file, if not included already (e.g. composer installation)
         if (!class_exists('\FPDM')) {

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "require": {
         "typo3/cms-core": "^10.4 || ^11.5",
         "tmw/fpdm": "^2.9",
-		"in2code/powermail": "^8 || ^9 || ^10.4"
+		"in2code/powermail": "^8 || ^9 || ^10"
     },
 	"extra": {
 		"typo3/cms": {

--- a/composer.json
+++ b/composer.json
@@ -14,9 +14,9 @@
     "license": ["GPL-2.0+"],
     "keywords": ["pdf", "TYPO3", "powermail"],
     "require": {
-        "typo3/cms-core": "^10.4",
+        "typo3/cms-core": "^10.4 || ^11.5",
         "tmw/fpdm": "^2.9",
-		"in2code/powermail": "^8"
+		"in2code/powermail": "^8 || ^9 || ^10.4"
     },
 	"extra": {
 		"typo3/cms": {

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -30,9 +30,9 @@ $EM_CONF[$_EXTKEY] = array (
 	array (
 		'depends' =>
 		array (
-            'typo3' => '10.4.0-10.99.99',
-            'php' => '7.2.0-7.99.99',
-			'powermail' => '8.0.0-8.99.99',
+            'typo3' => '10.4.0-11.99.99',
+            'php' => '7.2.0-8.99.99',
+			'powermail' => '8.0.0-19.99.99',
 		),
 		'conflicts' =>
 		array (

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -32,7 +32,7 @@ $EM_CONF[$_EXTKEY] = array (
 		array (
             'typo3' => '10.4.0-11.99.99',
             'php' => '7.2.0-8.99.99',
-			'powermail' => '8.0.0-19.99.99',
+			'powermail' => '8.0.0-10.99.99',
 		),
 		'conflicts' =>
 		array (


### PR DESCRIPTION
Changes for TYPO3 v11 support and powermail ^9 and ^10
support. The Extbase Signal Slot is not replaced (though
deprecated) since this is still used in powermail.

Resolves: #13
Resolves: #19
